### PR TITLE
Refactor test setup to auto-resolve released versions

### DIFF
--- a/test/common.sh
+++ b/test/common.sh
@@ -80,6 +80,7 @@ function knative_setup() {
   # Defined by knative/hack/library.sh
   kubectl apply --filename ${KNATIVE_SERVING_RELEASE_CRDS}
   kubectl apply --filename ${KNATIVE_SERVING_RELEASE_CORE}
+  kubectl apply --filename ${KNATIVE_NET_ISTIO_RELEASE}
   wait_until_pods_running knative-serving || return 1
 
   local eventing_version=${KNATIVE_EVENTING_VERSION:-latest}

--- a/test/common.sh
+++ b/test/common.sh
@@ -36,35 +36,55 @@ function cluster_setup() {
   ${REPO_ROOT_DIR}/hack/build.sh -f || return 1
 }
 
+# Copied from knative/serving setup script:
+# https://github.com/knative/serving/blob/main/test/e2e-networking-library.sh#L17
+function install_istio() {
+  if [[ -z "${ISTIO_VERSION:-}" ]]; then
+    readonly ISTIO_VERSION="stable"
+  fi
+  header "Installing Istio ${ISTIO_VERSION}"
+
+  LATEST_NET_ISTIO_RELEASE_VERSION=$(
+  curl -L --silent "https://api.github.com/repos/knative/net-istio/releases" | grep '"tag_name"' \
+    | cut -f2 -d: | sed "s/[^v0-9.]//g" | sort | tail -n1)
+
+  # And checkout the setup script based on that release
+  local NET_ISTIO_DIR=$(mktemp -d)
+  (
+    cd $NET_ISTIO_DIR \
+      && git init \
+      && git remote add origin https://github.com/knative-sandbox/net-istio.git \
+      && git fetch --depth 1 origin $LATEST_NET_ISTIO_RELEASE_VERSION \
+      && git checkout FETCH_HEAD
+  )
+
+  if [[ -z "${ISTIO_PROFILE:-}" ]]; then
+    readonly ISTIO_PROFILE="istio-ci-no-mesh.yaml"
+  fi
+
+  if [[ -n "${CLUSTER_DOMAIN:-}" ]]; then
+    sed -ie "s/cluster\.local/${CLUSTER_DOMAIN}/g" ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/${ISTIO_PROFILE}
+  fi
+
+  echo ">> Installing Istio"
+  echo "Istio version: ${ISTIO_VERSION}"
+  echo "Istio profile: ${ISTIO_PROFILE}"
+  ${NET_ISTIO_DIR}/third_party/istio-${ISTIO_VERSION}/install-istio.sh ${ISTIO_PROFILE}
+
+}
+
 function knative_setup() {
-  local serving_version=${KNATIVE_SERVING_VERSION:-latest}
-  header "Installing Knative Serving (${serving_version})"
+  install_istio
 
-  if [ "${serving_version}" = "latest" ]; then
-    start_latest_knative_serving
-  else
-    start_release_knative_serving "${serving_version}"
-  fi
+  header "Installing Knative Serving"
+  # Defined by knative/hack/library.sh
+  kubectl apply --filename ${KNATIVE_SERVING_RELEASE_CRDS}
+  kubectl apply --filename ${KNATIVE_SERVING_RELEASE_CORE}
 
-  local eventing_version=${KNATIVE_EVENTING_VERSION:-latest}
-  header "Installing Knative Eventing (${eventing_version})"
-
-  if [ "${eventing_version}" = "latest" ]; then
-    start_latest_knative_eventing
-
-    subheader "Installing eventing extension: sugar-controller (${eventing_version})"
-    # install the sugar controller
-    kubectl apply --filename https://storage.googleapis.com/knative-nightly/eventing/latest/eventing-sugar-controller.yaml
-    wait_until_pods_running knative-eventing || return 1
-
-  else
-    start_release_knative_eventing "${eventing_version}"
-
-    subheader "Installing eventing extension: sugar-controller (${eventing_version})"
-    # install the sugar controller
-    kubectl apply --filename https://storage.googleapis.com/knative-releases/eventing/previous/v${eventing_version}/eventing-sugar-controller.yaml
-    wait_until_pods_running knative-eventing || return 1
-  fi
+  header "Installing Knative Eventing"
+  # Defined by knative/hack/library.sh
+  kubectl apply --filename ${KNATIVE_EVENTING_RELEASE}
+  kubectl apply --filename ${KNATIVE_EVENTING_SUGAR_CONTROLLER_RELEASE}
 }
 
 function kafka_setup() {

--- a/test/common.sh
+++ b/test/common.sh
@@ -80,11 +80,14 @@ function knative_setup() {
   # Defined by knative/hack/library.sh
   kubectl apply --filename ${KNATIVE_SERVING_RELEASE_CRDS}
   kubectl apply --filename ${KNATIVE_SERVING_RELEASE_CORE}
+  wait_until_pods_running knative-serving || return 1
 
+  local eventing_version=${KNATIVE_EVENTING_VERSION:-latest}
   header "Installing Knative Eventing"
   # Defined by knative/hack/library.sh
   kubectl apply --filename ${KNATIVE_EVENTING_RELEASE}
   kubectl apply --filename ${KNATIVE_EVENTING_SUGAR_CONTROLLER_RELEASE}
+  wait_until_pods_running knative-eventing || return 1
 }
 
 function kafka_setup() {

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -23,9 +23,6 @@ export PATH=$PATH:${REPO_ROOT_DIR}
 # Will create and delete this namespace (used for all tests, modify if you want a different one used)
 export KN_E2E_NAMESPACE=kne2etests
 
-export KNATIVE_EVENTING_VERSION="0.22.0"
-export KNATIVE_SERVING_VERSION="0.22.0"
-
 # Strimzi installation config template used for starting up Kafka clusters.
 readonly STRIMZI_INSTALLATION_CONFIG_TEMPLATE="${REPO_ROOT_DIR}/test/config/100-strimzi-cluster-operator-0.20.0.yaml"
 # Strimzi installation config.
@@ -41,12 +38,14 @@ readonly KAFKA_CRD_CONFIG_TEMPLATE_DIR="kafka/channel/config"
 readonly KAFKA_CRD_CONFIG_TEMPLATE="400-kafka-config.yaml"
 # Real Kafka channel CRD config , generated from the template directory and modified template file.
 readonly KAFKA_CRD_CONFIG_DIR="$(mktemp -d)"
-# Kafka channel CRD config template directory.
-readonly KAFKA_SOURCE_CRD_YAML="https://github.com/knative-sandbox/eventing-kafka/releases/download/v0.22.0/source.yaml"
+# Resolve the latest release eventing-kafka source.yaml file
+# Nightly is used for 'main' branch, for any 'release-*' branch the corresponding eventing-kafka released version
+readonly KAFKA_SOURCE_CRD_YAML="$(get_latest_knative_yaml_source "eventing-kafka" "source")"
+
 
 run() {
   # Create cluster
-  initialize $@
+  initialize $@ --skip-istio-addon
 
   # Kafka setup
   eval plugin_test_setup || fail_test


### PR DESCRIPTION
## Description

This PR leverages `knative.dev/hack` functions to resolve appropriate release version of components to setup for E2E tests.

The setup template:
- `main` branch uses `nightly` yamls - that's usually what we want to test with updated dependencies etc.
- `release-*` - once release is cut, the corresponding released version is resolved by the [hack's function](https://github.com/knative/hack/blob/main/library.sh#L740-L765)

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Remove statically defined Serving, Eventing, Eventing Kafka versions
* Add the standalone Istio setup (same as `client`)
* Refactor test setup to auto-resolve released versions


