### PR TITLE
Fix source target to be Knative Service

### DIFF
--- a/pkg/factories/rune_factory_test.go
+++ b/pkg/factories/rune_factory_test.go
@@ -138,6 +138,6 @@ func newKafkaSource(name string) *v1beta1.KafkaSource {
 		BootstrapServers([]string{"test.server.org"}).
 		Topics([]string{"topic"}).
 		ConsumerGroup("mygroup").
-		Sink(&v1.Destination{Ref: &v1.KReference{Name: "mysvc", Kind: "Service"}}).
+		Sink(&v1.Destination{Ref: &v1.KReference{Name: "mysvc", Kind: "Service", APIVersion: "serving.knative.dev/v1"}}).
 		Build()
 }


### PR DESCRIPTION
## Description

On the `client` side there's more strict rule to determine ksvc versus plain k8s Service. 

## Changes

<!-- Please add list of more detailed changes. These changes should be reflected also in the commit messages -->

* Fix creation of Knative Service in tests to be recognized by `describe` cmds

## Reference

Fixes failing test in #98